### PR TITLE
Don't load artifactory credentials in library's gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,35 +1,3 @@
-def getArtifactoryCredentials(name) {
-  def propName = 'wultraArtifactory_' + name
-  // At first, try root project's ext dictionary
-  if (rootProject.ext.has(propName)) {
-    //logger.println('Malwarelytics property ' + propName + ' resolved from ext')
-    return rootProject.ext.get(propName)
-  }
-  def propFiles = [
-    project.rootProject.file('local.properties'),
-    project.file('local.properties')
-  ]
-  for (file in propFiles) {
-    if (file.canRead()) {
-      def props = new Properties()
-      props.load(file.newDataInputStream())
-      def value = props[propName]
-      if (value != null) {
-        //logger.println('Malwarelytics property ' + propName + ' resolved from ' + file.name)
-        return value
-      }
-    }
-  }
-  logger.error('Failed to resolve required property: ' + propName)
-  return null
-}
-
-project.ext {
-  artifactoryUrl = 'https://wultra.jfrog.io/artifactory/malwarelytics-android/'
-  artifactoryUser = getArtifactoryCredentials('username')
-  artifactoryPass = getArtifactoryCredentials('password')
-}
-
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["Malwarelytics_kotlinVersion"]
@@ -95,28 +63,14 @@ android {
 repositories {
   mavenCentral()
   google()
-  maven {
-    name "WultraMalwarelyticsArtifactory"
-    url project.ext.get('artifactoryUrl')
-    credentials {
-      username project.ext.get('artifactoryUser')
-      password project.ext.get('artifactoryPass')
-    }
-  }
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
 def antivirus_version = getExtOrDefault("antivirusVersion")
 
 dependencies {
-  if (project == rootProject) {
-    // The standalone build require to specify exact version of RN
-    def rnVersion = getExtOrDefault("reactNativeVersion")
-    implementation "com.facebook.react:react-android:${rnVersion}"
-  } else {
-    // This works for RN versions > 0.71
-    implementation "com.facebook.react:react-android"
-  }
+  // This works for RN versions > 0.71
+  implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.wultra.android.antimalware:antivirus:$antivirus_version"
 }

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -35,6 +35,8 @@ allProjects {
 }
 ```
 
+In the same file, look for `minSdkVersion` and make sure that it's higher or equal to `22`.
+
 If you don't want to expose your credentials in the gradle file, then use the script to load the credentials from `local.properties`. For example:
 
 ```gradle
@@ -61,8 +63,17 @@ def loadArtifactoryCredentials(name) {
     return null
 }
 
-def artifactoryUsername = loadArtifactoryCredentials('username') // wultraArtifactory_username
-def artifactoryPassword = loadArtifactoryCredentials('password') // wultraArtifactory_password
+allProjects {
+    repositories {
+        maven {
+            url 'https://wultra.jfrog.io/artifactory/malwarelytics-android/'
+            credentials {
+                username loadArtifactoryCredentials('username') // wultraArtifactory_username
+                password loadArtifactoryCredentials('password') // wultraArtifactory_password
+            }
+        }
+    }
+}
 ```
 
 ### Configure CocoaPods

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -28,9 +28,6 @@ def loadArtifactoryCredentials(name) {
     return null
 }
 
-def artifactoryUsername = loadArtifactoryCredentials('username') // wultraArtifactory_username
-def artifactoryPassword = loadArtifactoryCredentials('password') // wultraArtifactory_password
-
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
@@ -56,8 +53,8 @@ allprojects {
         maven {
             url 'https://wultra.jfrog.io/artifactory/malwarelytics-android/'
             credentials {
-                username artifactoryUsername
-                password artifactoryPassword
+                username loadArtifactoryCredentials('username')
+                password loadArtifactoryCredentials('password')
             }
         }
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR removes loading artifactory credentials from the library's `build.gradle`. The reason for that is:

- It cause problems in case that credentials are not specified in local.properties or in `ext` section.
- We use `example` project for the development, so we don't need to open the library's gradle file directly
- The recommended way is to add our maven repo on the application's build script gradle file. 
- In context of application build, the repositories defined by libraries itself are ignored.
