### PR TITLE
Fix #45: Proper tapjacking protection init

### DIFF
--- a/android/src/main/java/com/wultra/android/malwarelytics/reactnative/AVConfig.kt
+++ b/android/src/main/java/com/wultra/android/malwarelytics/reactnative/AVConfig.kt
@@ -79,7 +79,7 @@ fun ReadableMap.toAppProtectionConfig(context: Context, javaPackagePath: String)
             it.boolOptAt("block", jsTapjacking)?.let { raspBuilder.blockTapjacking(it) }
             it.stringOptAt("blockSensitivity", jsTapjacking)?.let {
                 try {
-                    ThreatIndex.valueOf(it)
+                    raspBuilder.blockTapjackingSensitivity(ThreatIndex.valueOf(it))
                 } catch (t: Throwable) {
                     throw InvalidConfigException("blockSensitivity", jsTapjacking)
                 }

--- a/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
+++ b/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
@@ -177,20 +177,19 @@ class MalwarelyticsModule(reactContext: ReactApplicationContext) :
         changeState(State.PENDING_INIT)
         service.initializeAsync(config, object : AppProtection.InitializationObserver {
             override fun onInitialized(initializationResult: AppProtection.InitializationResult) {
+                // Protect the current activity against tapjacking. We're already on the main thread.
+                if (service.isInitialized()) {
+                    // Get the current activity from RN context.
+                    val activity = reactApplicationContext.currentActivity
+                    if (activity != null) {
+                        service.getRaspManager().protectActivity(activity)
+                    }
+                }
+                // Now process the initialization result in worker's thread
                 resolveOnQueue(promise, null) {
                     changeState(State.READY)
                     moduleInitResult = initializationResult
                     service.getRaspManager().registerRaspObserver(raspObserver)
-                    executeOnMainThread {
-                        // Make sure that service is still initialized.
-                        if (service.isInitialized()) {
-                            // Get the current activity from RN context.
-                            val activity = reactApplicationContext.currentActivity
-                            if (activity != null) {
-                                service.getRaspManager().protectActivity(activity)
-                            }
-                        }
-                    }
                     // Resolve the promise with initialization result
                     initializationResult.name
                 }

--- a/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
+++ b/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
@@ -16,11 +16,9 @@
 
 package com.wultra.android.malwarelytics.reactnative
 
-import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
-import android.os.Handler
 import android.util.Base64.encodeToString
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
@@ -632,16 +630,6 @@ class MalwarelyticsModule(reactContext: ReactApplicationContext) :
             action()
         } else {
             serialExecutor.execute(action)
-        }
-    }
-
-    /**
-     * Execute action on the main application's thread.
-     */
-    private fun executeOnMainThread(action: () -> Unit) {
-        val handler = Handler(reactApplicationContext.mainLooper)
-        handler.post {
-            action()
         }
     }
 

--- a/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
+++ b/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
@@ -178,12 +178,9 @@ class MalwarelyticsModule(reactContext: ReactApplicationContext) :
         service.initializeAsync(config, object : AppProtection.InitializationObserver {
             override fun onInitialized(initializationResult: AppProtection.InitializationResult) {
                 // Protect the current activity against tapjacking. We're already on the main thread.
-                if (service.isInitialized()) {
-                    // Get the current activity from RN context.
-                    val activity = reactApplicationContext.currentActivity
-                    if (activity != null) {
-                        service.getRaspManager().protectActivity(activity)
-                    }
+                val activity = reactApplicationContext.currentActivity
+                if (activity != null) {
+                    service.getRaspManager().protectActivity(activity)
                 }
                 // Now process the initialization result in worker's thread
                 resolveOnQueue(promise, null) {

--- a/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
+++ b/android/src/main/java/com/wultra/android/malwarelytics/reactnative/MalwarelyticsModule.kt
@@ -16,9 +16,11 @@
 
 package com.wultra.android.malwarelytics.reactnative
 
+import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import android.os.Handler
 import android.util.Base64.encodeToString
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
@@ -179,6 +181,17 @@ class MalwarelyticsModule(reactContext: ReactApplicationContext) :
                     changeState(State.READY)
                     moduleInitResult = initializationResult
                     service.getRaspManager().registerRaspObserver(raspObserver)
+                    executeOnMainThread {
+                        // Make sure that service is still initialized.
+                        if (service.isInitialized()) {
+                            // Get the current activity from RN context.
+                            val activity = reactApplicationContext.currentActivity
+                            if (activity != null) {
+                                service.getRaspManager().protectActivity(activity)
+                            }
+                        }
+                    }
+                    // Resolve the promise with initialization result
                     initializationResult.name
                 }
             }
@@ -623,6 +636,16 @@ class MalwarelyticsModule(reactContext: ReactApplicationContext) :
             action()
         } else {
             serialExecutor.execute(action)
+        }
+    }
+
+    /**
+     * Execute action on the main application's thread.
+     */
+    private fun executeOnMainThread(action: () -> Unit) {
+        val handler = Handler(reactApplicationContext.mainLooper)
+        handler.post {
+            action()
         }
     }
 

--- a/example/src/Config.ts
+++ b/example/src/Config.ts
@@ -52,7 +52,7 @@ const defaultConfig: MalwarelyticsConfig = {
         rasp: {
             root: { action: 'NOTIFY' },
             tapjacking: {
-                blockSensitivity: 'SAFE'
+                //blockSensitivity: 'DANGEROUS'
             }
         },
         antivirus: {

--- a/example/src/Config.ts
+++ b/example/src/Config.ts
@@ -50,7 +50,10 @@ const defaultConfig: MalwarelyticsConfig = {
         //     signaturePublicKey: "your-sign-pk-for-android-app"
         // },
         rasp: {
-            root: { action: 'NOTIFY' }
+            root: { action: 'NOTIFY' },
+            tapjacking: {
+                blockSensitivity: 'SAFE'
+            }
         },
         antivirus: {
             enableSilentMode: false


### PR DESCRIPTION
This PR fixes two problems in tapjacking protection initialization:

- The sensitivity was not properly applied from JS config to native config
- The application's main activity was not registered for the protection